### PR TITLE
Fix: Allow users to configure only the providers they want

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -294,6 +294,13 @@ export class ConfigLoader {
   }
 
   /**
+   * Get the first provider that has an API key configured
+   */
+  getFirstConfiguredProvider(config: AppConfig): Provider | undefined {
+    return config.providers.find(p => p.apiKey && p.apiKey.length > 0);
+  }
+
+  /**
    * Check if setup is needed (no API keys configured)
    */
   needsSetup(config: AppConfig): boolean {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -67,6 +67,31 @@ export class SetupManager {
       return false;
     }
 
+    // Switch to the first configured provider if the current active provider isn't configured
+    const activeProvider = this.configLoader.getActiveProvider(this.config);
+    if (!activeProvider?.apiKey) {
+      const firstConfigured = this.configLoader.getFirstConfiguredProvider(this.config);
+      if (firstConfigured) {
+        console.log(`\n✓ Setting active provider to ${firstConfigured.name}...`);
+
+        // Update active provider
+        this.config.config.activeProvider = firstConfigured.id;
+
+        // Update active model to first model of the new provider
+        const firstModel = firstConfigured.models[0];
+        if (firstModel) {
+          this.config.config.activeModel = {
+            id: firstModel.id,
+            display_name: firstModel.display_name,
+            pricing: firstModel.pricing,
+          };
+        }
+
+        // Save the updated config
+        await this.configLoader.save(this.config);
+      }
+    }
+
     console.log('\n✓ Setup complete! Starting TermChat...\n');
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes the issue where users would get an error if they only configured one AI provider during setup.

**Problem**: After first-time setup, if a user only configured OpenAI (but not Anthropic), the app would throw an error:
```
❌ Configuration Error: Provider "anthropic" is missing an API key. Use /configure anthropic to add one.
```

**Root cause**: The default active provider was always Anthropic (first in the list), even when the user didn't configure it.

## Changes

### New Helper Method (`src/config.ts`)
- Added `getFirstConfiguredProvider()` - Returns the first provider that has an API key

### Auto-Switch Logic (`src/setup.ts`)
- After setup completes, check if the current active provider has an API key
- If not, automatically switch to the first provider that was configured
- Update the active model to match the new provider
- Save the configuration

## Behavior

### Before
1. User runs first-time setup
2. User chooses to configure only OpenAI (skips Anthropic)
3. Setup completes but active provider is still "anthropic"
4. App tries to start with Anthropic (no API key)
5. **Error**: "Provider anthropic is missing an API key" ❌

### After
1. User runs first-time setup
2. User chooses to configure only OpenAI (skips Anthropic)
3. Setup detects active provider (Anthropic) has no API key
4. **Auto-switches** to OpenAI as the active provider
5. Updates active model to GPT-5 (first model of OpenAI)
6. App starts successfully ✅

## Testing

- ✅ Created fresh config with Anthropic as default
- ✅ Configured only OpenAI during setup
- ✅ Setup automatically switched to OpenAI
- ✅ Config saved with correct active provider and model
- ✅ Config reloaded successfully without errors
- ✅ App starts with the configured provider

## Impact

Users can now choose to configure only the AI providers they want to use, without needing to configure all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)